### PR TITLE
Fix for escaped mutants.

### DIFF
--- a/tests/ShippingCalculatorTest.php
+++ b/tests/ShippingCalculatorTest.php
@@ -22,4 +22,24 @@ class ShippingCalculatorTest extends TestCase
 
         $this->assertFalse($isShippingFree);
     }
+
+    public function test_free_shipping_should_not_be_applied_when_price_is_to_low2(): void {
+
+        $product = new Product("product1", 40, "coupon");
+        $carrier = new Carrier("PostNl", true);
+        $calc = new ShippingCalculator($carrier);
+        $isShippingFree = $calc->isShippingFree($product);
+
+        $this->assertTrue($isShippingFree);
+    }
+
+    public function test_free_shipping_should_not_be_applied_when_price_is_to_low3(): void {
+
+        $product = new Product("product1", 35, "coupon");
+        $carrier = new Carrier("PostNl", true);
+        $calc = new ShippingCalculator($carrier);
+        $isShippingFree = $calc->isShippingFree($product);
+
+        $this->assertFalse($isShippingFree);
+    }
 }


### PR DESCRIPTION
# Example
Generated with the Mutation Testing playground: [Playground demo](https://infection-php.dev/r/3w74)
![image](https://user-images.githubusercontent.com/52493874/209090929-b7bd7430-31a9-4505-8408-0a86de94649f.png)
![image](https://user-images.githubusercontent.com/52493874/209089363-b936f963-40a1-4be0-a32d-3ae44755143e.png)

## Escaped mutations (Test passes, but it should fail)
![image](https://user-images.githubusercontent.com/52493874/209088464-a71fbcea-f56e-428c-be52-7ea16192b37e.png)

## Killed mutations (Test failes, because of mutation in source code)
![image](https://user-images.githubusercontent.com/52493874/209091039-fb318db5-77ef-4808-98a6-e614d137bf2d.png)

# Mutation example in Scienta codebase (voor en na)
[infection.log](https://github.com/KoenvanMeijeren/PHP-code-tests-in-CI-CD/files/10285438/infection.log)

![MutatieOpScientaVoor](https://user-images.githubusercontent.com/26549123/209097782-af4e6938-9349-4865-8a71-735224df41c8.png)
![MutatieOpScientaNa](https://user-images.githubusercontent.com/26549123/209097773-824b9eab-9a84-492e-b1e4-81a6ac5568a3.png)

https://github.com/Beurni/scienta/compare/develop...Beurni:scienta:sc-22421/mutation-testing-implementation

